### PR TITLE
P4-2237 this change maps the imported location types to abbreviations which will end up in the generated spreadsheet.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ out/
 .DS_Store
 
 /dps-gradle-spring-boot-suppressions.xml
+
+*.xlsx
+*.jsonl
+

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/Location.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/Location.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.pecs.jpc.location
 
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 import javax.persistence.Column
 import javax.persistence.Entity
+import javax.persistence.Enumerated
+import javax.persistence.EnumType
 import javax.persistence.Id
 import javax.persistence.Table
 import javax.validation.constraints.NotBlank
@@ -11,9 +13,8 @@ import javax.validation.constraints.NotBlank
 @Entity
 @Table(name = "LOCATIONS")
 data class Location(
-        @Column(nullable = false)
-        @get: NotBlank(message = "location type cannot be blank")
-        val locationType: String,
+        @Enumerated(EnumType.STRING)
+        val locationType: LocationType,
 
         @Column(unique = true, nullable = false)
         @get: NotBlank(message = "NOMIS agency id cannot be blank")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationType.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.location
+
+/**
+ * Enum responsible for mapping location type string values in the locations spreadsheet to an abbreviation (in this case the enum value).
+ */
+enum class LocationType(val label: String) {
+
+    AP("Airport"),
+    CC("Crown Court"),
+    CM("Combined Court"),
+    CO("County Court"),
+    HP("Hospital"),
+    IM("Immigration"),
+    MC("Mag Court"),
+    O("Other"),
+    PR("Prison"),
+    PS("Police"),
+    SCH("SCH"),
+    STC("STC");
+
+    companion object {
+        /**
+         * Attempts to map the supplied value to the supported locations types.  Returns null if no match found.
+         */
+        fun map(value: String): LocationType? = values().firstOrNull { it.label.toUpperCase() == value.toUpperCase().trim() }
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationTab.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationTab.kt
@@ -5,6 +5,7 @@ import org.apache.poi.ss.usermodel.Row
 import org.apache.poi.ss.usermodel.Sheet
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import uk.gov.justice.digital.hmpps.pecs.jpc.location.Location
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
 
 private const val TYPE = 1
 private const val SITE = 2
@@ -25,12 +26,13 @@ enum class LocationTab(val tabName: String) {
 
     fun map(cells: List<Cell>): Location {
         return Location(
-                locationType = cells[TYPE].stringCellValue.toUpperCase().trim(),
+                locationType = LocationType.map(cells[TYPE].stringCellValue.toUpperCase().trim())
+                        ?: throw IllegalArgumentException("Unsupported location type: " + cells[TYPE].stringCellValue),
                 nomisAgencyId = cells[AGENCY].stringCellValue.trim(),
                 siteName = cells[SITE].stringCellValue.toUpperCase().trim())
     }
 
-    fun map(cells: Row): Location = map(cells.toList())
+    fun map(row: Row): Location = map(row.toList())
 
     fun sheet(locationsWorkbook: XSSFWorkbook): Sheet = locationsWorkbook.getSheet(tabName)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationRepositoryTest.kt
@@ -24,7 +24,7 @@ class LocationRepositoryTest {
 
     @Test
     fun `can save location`() {
-        val location = repository.save(Location("location type", "agency id", "site name"))
+        val location = repository.save(Location(LocationType.PR, "agency id", "site name"))
 
         entityManager.flush()
 
@@ -34,7 +34,7 @@ class LocationRepositoryTest {
     @Test
     fun `should throw constraint violation if fields empty`() {
         assertThatThrownBy {
-            repository.save(Location("", "", ""))
+            repository.save(Location(LocationType.PR, "", ""))
             entityManager.flush()
         }.isInstanceOf(ConstraintViolationException::class.java)
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationTypeTest.kt
@@ -2,104 +2,41 @@ package uk.gov.justice.digital.hmpps.pecs.jpc.location
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class LocationTypeTest {
 
-    @Test
-    fun `airport location type is mapped`() {
-        assertThat(LocationType.map("Airport")).isEqualTo(LocationType.AP)
-        assertThat(LocationType.map(" aiRport ")).isEqualTo(LocationType.AP)
-        assertThat(LocationType.map("AIRPORT")).isEqualTo(LocationType.AP)
+    fun testData(): Stream<Arguments> =
+            Stream.of(
+                    Arguments.of("Airport", " aiRport ", "AIRPORT", LocationType.AP),
+                    Arguments.of("Combined Court"," CombineD Court ", "COMBINED COURT", LocationType.CM),
+                    Arguments.of("County Court"," county Court ", "COUNTY COURT", LocationType.CO),
+                    Arguments.of("Crown Court"," CrowN court ", "CROWN COURT", LocationType.CC),
+                    Arguments.of("Hospital"," hOspital ", "HOSPITAL", LocationType.HP),
+                    Arguments.of("Immigration"," immIgration ", "IMMIGRATION", LocationType.IM),
+                    Arguments.of("Mag Court"," maG courT ", "MAG COURT", LocationType.MC),
+                    Arguments.of("Other"," othEr ", "OTHER", LocationType.O),
+                    Arguments.of("Police"," policE ", "POLICE", LocationType.PS),
+                    Arguments.of("Prison"," prisOn ", "PRISON", LocationType.PR),
+                    Arguments.of("sch"," sCh ", "SCH", LocationType.SCH),
+                    Arguments.of("stc"," stC ", "STC", LocationType.STC)
+            )
+
+    @ParameterizedTest
+    @MethodSource("testData")
+    fun `test all locations map exact, mixed with whitespace and all uppercase` (exact: String, mixedCaseAndWhiteSpace: String, allUpperCase: String, expected: LocationType) {
+        assertThat(LocationType.map(exact)).isEqualTo(expected)
+        assertThat(LocationType.map(mixedCaseAndWhiteSpace)).isEqualTo(expected)
+        assertThat(LocationType.map(allUpperCase)).isEqualTo(expected)
     }
 
     @Test
-    fun `combined court location type is mapped`() {
-        assertThat(LocationType.map("Combined Court")).isEqualTo(LocationType.CM)
-        assertThat(LocationType.map(" CombineD Court ")).isEqualTo(LocationType.CM)
-        assertThat(LocationType.map("COMBINED COURT")).isEqualTo(LocationType.CM)
-    }
-
-    @Test
-    fun `county court location type is mapped`() {
-        assertThat(LocationType.map("County Court")).isEqualTo(LocationType.CO)
-        assertThat(LocationType.map(" county Court ")).isEqualTo(LocationType.CO)
-        assertThat(LocationType.map("COUNTY COURT")).isEqualTo(LocationType.CO)
-    }
-
-    @Test
-    fun `crown court location type is mapped`() {
-        assertThat(LocationType.map("Crown Court")).isEqualTo(LocationType.CC)
-        assertThat(LocationType.map(" CrowN court ")).isEqualTo(LocationType.CC)
-        assertThat(LocationType.map("CROWN COURT")).isEqualTo(LocationType.CC)
-    }
-
-    @Test
-    fun `hospital location type is mapped`() {
-        assertThat(LocationType.map("Hospital")).isEqualTo(LocationType.HP)
-        assertThat(LocationType.map(" hOspital ")).isEqualTo(LocationType.HP)
-        assertThat(LocationType.map("HOSPITAL")).isEqualTo(LocationType.HP)
-    }
-
-    @Test
-    fun `immigration location type is mapped`() {
-        assertThat(LocationType.map("Immigration")).isEqualTo(LocationType.IM)
-        assertThat(LocationType.map(" immigration ")).isEqualTo(LocationType.IM)
-        assertThat(LocationType.map("IMMIGRATION")).isEqualTo(LocationType.IM)
-    }
-
-    @Test
-    fun `magistrates court location type is mapped`() {
-        assertThat(LocationType.map("Mag Court")).isEqualTo(LocationType.MC)
-        assertThat(LocationType.map(" maG courT ")).isEqualTo(LocationType.MC)
-        assertThat(LocationType.map("MAG COURT")).isEqualTo(LocationType.MC)
-    }
-
-    @Test
-    fun `other location type is mapped`() {
-        assertThat(LocationType.map("Other")).isEqualTo(LocationType.O)
-        assertThat(LocationType.map(" other ")).isEqualTo(LocationType.O)
-        assertThat(LocationType.map("OTHER")).isEqualTo(LocationType.O)
-    }
-
-    @Test
-    fun `police location type is mapped`() {
-        assertThat(LocationType.map("Police")).isEqualTo(LocationType.PS)
-        assertThat(LocationType.map(" police ")).isEqualTo(LocationType.PS)
-        assertThat(LocationType.map("POLICE")).isEqualTo(LocationType.PS)
-    }
-
-    @Test
-    fun `prison location type is mapped`() {
-        assertThat(LocationType.map("Prison")).isEqualTo(LocationType.PR)
-        assertThat(LocationType.map(" prison ")).isEqualTo(LocationType.PR)
-        assertThat(LocationType.map("PRISON")).isEqualTo(LocationType.PR)
-    }
-
-    @Test
-    fun `secure children's home location type is mapped`() {
-        assertThat(LocationType.map("SCH")).isEqualTo(LocationType.SCH)
-        assertThat(LocationType.map(" sch ")).isEqualTo(LocationType.SCH)
-    }
-
-    @Test
-    fun `secure training centre location type is mapped`() {
-        assertThat(LocationType.map("STC")).isEqualTo(LocationType.STC)
-        assertThat(LocationType.map(" stc ")).isEqualTo(LocationType.STC)
-    }
-
-    @Test
-    fun `location types are not mapped`() {
-        assertThat(LocationType.map("Alrport")).isNull()
-        assertThat(LocationType.map("C0MBINED COURT")).isNull()
-        assertThat(LocationType.map("C0UNTY COURT")).isNull()
-        assertThat(LocationType.map("CR0WN Court")).isNull()
-        assertThat(LocationType.map("H0spital")).isNull()
-        assertThat(LocationType.map("IMMIGRATI0N")).isNull()
-        assertThat(LocationType.map("MAGISTRATES COURT")).isNull()
-        assertThat(LocationType.map("0ther")).isNull()
-        assertThat(LocationType.map("Pris0n")).isNull()
-        assertThat(LocationType.map("P0l1ce")).isNull()
-        assertThat(LocationType.map("SCHH")).isNull()
-        assertThat(LocationType.map("STCC")).isNull()
+    fun `unrecognised location type is not mapped`() {
+        assertThat(LocationType.map("garbage")).isNull()
     }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationTypeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/LocationTypeTest.kt
@@ -1,0 +1,105 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.location
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class LocationTypeTest {
+
+    @Test
+    fun `airport location type is mapped`() {
+        assertThat(LocationType.map("Airport")).isEqualTo(LocationType.AP)
+        assertThat(LocationType.map(" aiRport ")).isEqualTo(LocationType.AP)
+        assertThat(LocationType.map("AIRPORT")).isEqualTo(LocationType.AP)
+    }
+
+    @Test
+    fun `combined court location type is mapped`() {
+        assertThat(LocationType.map("Combined Court")).isEqualTo(LocationType.CM)
+        assertThat(LocationType.map(" CombineD Court ")).isEqualTo(LocationType.CM)
+        assertThat(LocationType.map("COMBINED COURT")).isEqualTo(LocationType.CM)
+    }
+
+    @Test
+    fun `county court location type is mapped`() {
+        assertThat(LocationType.map("County Court")).isEqualTo(LocationType.CO)
+        assertThat(LocationType.map(" county Court ")).isEqualTo(LocationType.CO)
+        assertThat(LocationType.map("COUNTY COURT")).isEqualTo(LocationType.CO)
+    }
+
+    @Test
+    fun `crown court location type is mapped`() {
+        assertThat(LocationType.map("Crown Court")).isEqualTo(LocationType.CC)
+        assertThat(LocationType.map(" CrowN court ")).isEqualTo(LocationType.CC)
+        assertThat(LocationType.map("CROWN COURT")).isEqualTo(LocationType.CC)
+    }
+
+    @Test
+    fun `hospital location type is mapped`() {
+        assertThat(LocationType.map("Hospital")).isEqualTo(LocationType.HP)
+        assertThat(LocationType.map(" hOspital ")).isEqualTo(LocationType.HP)
+        assertThat(LocationType.map("HOSPITAL")).isEqualTo(LocationType.HP)
+    }
+
+    @Test
+    fun `immigration location type is mapped`() {
+        assertThat(LocationType.map("Immigration")).isEqualTo(LocationType.IM)
+        assertThat(LocationType.map(" immigration ")).isEqualTo(LocationType.IM)
+        assertThat(LocationType.map("IMMIGRATION")).isEqualTo(LocationType.IM)
+    }
+
+    @Test
+    fun `magistrates court location type is mapped`() {
+        assertThat(LocationType.map("Mag Court")).isEqualTo(LocationType.MC)
+        assertThat(LocationType.map(" maG courT ")).isEqualTo(LocationType.MC)
+        assertThat(LocationType.map("MAG COURT")).isEqualTo(LocationType.MC)
+    }
+
+    @Test
+    fun `other location type is mapped`() {
+        assertThat(LocationType.map("Other")).isEqualTo(LocationType.O)
+        assertThat(LocationType.map(" other ")).isEqualTo(LocationType.O)
+        assertThat(LocationType.map("OTHER")).isEqualTo(LocationType.O)
+    }
+
+    @Test
+    fun `police location type is mapped`() {
+        assertThat(LocationType.map("Police")).isEqualTo(LocationType.PS)
+        assertThat(LocationType.map(" police ")).isEqualTo(LocationType.PS)
+        assertThat(LocationType.map("POLICE")).isEqualTo(LocationType.PS)
+    }
+
+    @Test
+    fun `prison location type is mapped`() {
+        assertThat(LocationType.map("Prison")).isEqualTo(LocationType.PR)
+        assertThat(LocationType.map(" prison ")).isEqualTo(LocationType.PR)
+        assertThat(LocationType.map("PRISON")).isEqualTo(LocationType.PR)
+    }
+
+    @Test
+    fun `secure children's home location type is mapped`() {
+        assertThat(LocationType.map("SCH")).isEqualTo(LocationType.SCH)
+        assertThat(LocationType.map(" sch ")).isEqualTo(LocationType.SCH)
+    }
+
+    @Test
+    fun `secure training centre location type is mapped`() {
+        assertThat(LocationType.map("STC")).isEqualTo(LocationType.STC)
+        assertThat(LocationType.map(" stc ")).isEqualTo(LocationType.STC)
+    }
+
+    @Test
+    fun `location types are not mapped`() {
+        assertThat(LocationType.map("Alrport")).isNull()
+        assertThat(LocationType.map("C0MBINED COURT")).isNull()
+        assertThat(LocationType.map("C0UNTY COURT")).isNull()
+        assertThat(LocationType.map("CR0WN Court")).isNull()
+        assertThat(LocationType.map("H0spital")).isNull()
+        assertThat(LocationType.map("IMMIGRATI0N")).isNull()
+        assertThat(LocationType.map("MAGISTRATES COURT")).isNull()
+        assertThat(LocationType.map("0ther")).isNull()
+        assertThat(LocationType.map("Pris0n")).isNull()
+        assertThat(LocationType.map("P0l1ce")).isNull()
+        assertThat(LocationType.map("SCHH")).isNull()
+        assertThat(LocationType.map("STCC")).isNull()
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationTabTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/pecs/jpc/location/importer/LocationTabTest.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.pecs.jpc.location.importer
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import org.apache.poi.ss.usermodel.Cell
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.Test
+import uk.gov.justice.digital.hmpps.pecs.jpc.location.LocationType
+
+class LocationTabTest {
+
+    private val ignored: Cell = mock { on { it.stringCellValue } doReturn "ignored" }
+    private val unsupportedLocationType: Cell = mock { on { it.stringCellValue } doReturn "bad location" }
+    private val supportedLocationType: Cell = mock { on { it.stringCellValue } doReturn LocationType.CC.label }
+    private val site: Cell = mock { on { it.stringCellValue } doReturn "site" }
+    private val agency: Cell = mock { on { it.stringCellValue } doReturn "agency" }
+
+    @Test
+    fun `throws error for unsupported location type`() {
+        assertThatThrownBy { LocationTab.COURT.map(listOf(ignored, unsupportedLocationType, site, agency)) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .withFailMessage("Unsupported location type: ", unsupportedLocationType.stringCellValue)
+    }
+
+    @Test
+    fun `court location type is mapped correctly`() {
+        assertThat(LocationTab.COURT.map(listOf(ignored, supportedLocationType, site, agency)).locationType).isEqualTo(LocationType.CC)
+    }
+}


### PR DESCRIPTION
This change maps the incoming schedule 34 location types to a set of agreed abbreviations which will ultimately end up in the generated calculated journey pricing spreadsheets for a given supplier. 